### PR TITLE
ASC1-313: Update Mention Text Color

### DIFF
--- a/examples/src/Basic.tsx
+++ b/examples/src/Basic.tsx
@@ -20,6 +20,7 @@ export const Basic = () => {
                     label='Outlined'
                     fullWidth
                     defaultValue={defaultValue}
+                    highlightTextColor
                     dataSources={[
                         {
                             data: stormlight,

--- a/examples/src/Color.tsx
+++ b/examples/src/Color.tsx
@@ -11,7 +11,8 @@ export const Color = () => {
                 <Typography>
                     The color prop changes the outline color of the text field when focused. The mention highlight color
                     is also set to match. To change the mention highlight color independently of the outline color, use
-                    the highlightColor prop.
+                    the highlightColor prop. Use highlightTextColor to highlight mentions with text color instead of
+                    background color.
                 </Typography>
             </Stack>
 
@@ -100,6 +101,49 @@ export const Color = () => {
                     ]}
                     color='warning'
                     highlightColor='#616161'
+                    focused
+                />
+            </Stack>
+
+            <Stack direction='row' spacing={2}>
+                <MentionsTextField
+                    label='Text Color Highlighting'
+                    fullWidth
+                    defaultValue={defaultValue}
+                    dataSources={[
+                        {
+                            data: stormlight,
+                        },
+                    ]}
+                    highlightTextColor={true}
+                    focused
+                />
+
+                <MentionsTextField
+                    variant='filled'
+                    label='Filled with Text Color'
+                    fullWidth
+                    defaultValue={defaultValue}
+                    dataSources={[
+                        {
+                            data: stormlight,
+                        },
+                    ]}
+                    highlightTextColor={true}
+                    focused
+                />
+
+                <MentionsTextField
+                    variant='standard'
+                    label='Standard with Text Color'
+                    fullWidth
+                    defaultValue={defaultValue}
+                    dataSources={[
+                        {
+                            data: stormlight,
+                        },
+                    ]}
+                    highlightTextColor={true}
                     focused
                 />
             </Stack>

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -31,14 +31,33 @@ interface HighlighterProps<T extends BaseSuggestionData> {
 
     /** The color of the highlight. */
     color?: string;
+
+    /** Whether to use text color highlighting instead of background color. */
+    highlightTextColor?: boolean;
 }
 
 function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): ReactNode {
-    const { highlighterRef, cursorRef, selectionEnd, selectionStart, value, dataSources, multiline } = props;
+    const {
+        highlighterRef,
+        cursorRef,
+        selectionEnd,
+        selectionStart,
+        value,
+        dataSources,
+        multiline,
+        highlightTextColor,
+    } = props;
     const components: JSX.Element[] = [];
 
     const handleMention = (_markup: string, index: number, _plainTextIndex: number, id: string, display: string) => {
-        components.push(<Mention key={`${id}-${index}`} display={display} color={props.color} />);
+        components.push(
+            <Mention
+                key={`${id}-${index}`}
+                display={display}
+                color={props.color}
+                highlightTextColor={highlightTextColor}
+            />,
+        );
     };
 
     const handlePlainText = (text: string, index: number, indexInPlaintext: number) => {
@@ -54,7 +73,11 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
 
         if (!renderCursor) {
             components.push(
-                <Box key={`${index}-${indexInPlaintext}`} component='span' visibility='hidden'>
+                <Box
+                    key={`${index}-${indexInPlaintext}`}
+                    component='span'
+                    visibility={highlightTextColor ? 'visible' : 'hidden'}
+                >
                     {text}
                 </Box>,
             );
@@ -65,7 +88,11 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
 
             if (startText) {
                 components.push(
-                    <Box key={`${index}-${indexInPlaintext}-precursor`} component='span' visibility='hidden'>
+                    <Box
+                        key={`${index}-${indexInPlaintext}-precursor`}
+                        component='span'
+                        visibility={highlightTextColor ? 'visible' : 'hidden'}
+                    >
                         {startText}
                     </Box>,
                 );
@@ -75,7 +102,11 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
 
             if (endText) {
                 components.push(
-                    <Box key={`${index}-${indexInPlaintext}-postcursor`} component='span' visibility='hidden'>
+                    <Box
+                        key={`${index}-${indexInPlaintext}-postcursor`}
+                        component='span'
+                        visibility={highlightTextColor ? 'visible' : 'hidden'}
+                    >
                         {endText}
                     </Box>,
                 );

--- a/src/Mention.tsx
+++ b/src/Mention.tsx
@@ -7,9 +7,33 @@ interface MentionProps {
 
     /** The color of the highlight. */
     color?: string;
+
+    /** Whether to use text color highlighting instead of background color. */
+    highlightTextColor?: boolean;
 }
 
-const Mention: React.FC<MentionProps> = ({ display, color }) => {
+const Mention: React.FC<MentionProps> = ({ display, color, highlightTextColor }) => {
+    if (highlightTextColor) {
+        return (
+            <Box component='span' sx={{ position: 'relative' }}>
+                {display}
+                <Box
+                    component='span'
+                    sx={{
+                        position: 'absolute',
+                        left: '0px',
+                        top: '-2px',
+                        right: '0px',
+                        bottom: '0px',
+                        color: (theme) => theme.palette.primary.main,
+                    }}
+                >
+                    {display}
+                </Box>
+            </Box>
+        );
+    }
+
     return (
         <Box component='span' sx={{ position: 'relative' }}>
             {display}

--- a/src/MentionsTextField.tsx
+++ b/src/MentionsTextField.tsx
@@ -57,6 +57,13 @@ interface MentionsTextFieldBaseProps<T extends BaseSuggestionData> {
      * Collection of initiation options for the field
      */
     options?: MentionsTextFieldOptions;
+
+    /**
+     * If true, mentions will be highlighted with text color (theme.palette.primary.main)
+     * instead of background color.
+     * @default false
+     */
+    highlightTextColor?: boolean;
 }
 
 export type MentionsTextFieldProps<
@@ -97,7 +104,15 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
         input.setSelectionRange(selectionStart, selectionEnd);
     }, [selectionStart, selectionEnd, inputRef]);
 
-    const { value, defaultValue: _defaultValue, dataSources, highlightColor, options, ...others } = props;
+    const {
+        value,
+        defaultValue: _defaultValue,
+        dataSources,
+        highlightColor,
+        highlightTextColor,
+        options,
+        ...others
+    } = props;
     const finalValue = value !== undefined ? value : stateValue;
 
     const handleBlur = () => {
@@ -213,7 +228,11 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
         onSelect: handleSelect,
         onBlur: handleBlur,
         inputProps: {
-            sx: { overscrollBehavior: 'none' },
+            sx: {
+                overscrollBehavior: 'none',
+                color: highlightTextColor ? 'transparent' : 'inherit',
+                caretColor: highlightTextColor ? 'black' : 'inherit',
+            },
         },
     };
 
@@ -229,6 +248,7 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
                 inputRef={inputRef}
                 multiline={inputProps.multiline}
                 color={highlightColor || props.color}
+                highlightTextColor={highlightTextColor}
             />
             <TextField inputRef={(ref) => setInputRef(ref)} {...inputProps} />
             <SuggestionsOverlay


### PR DESCRIPTION
Ticket: https://augeomarketing.atlassian.net/browse/ASC1-313

Enable mentions to be highlighted with theme.palette.primary.main text color instead of background color

- Add highlightTextColor prop to MentionsTextField component
- Mentions rendering in front with theme.palette.primary.main color
- Use caretColor CSS property to maintain native cursor visibility on transparent input text

Testing instructions
- `npm run start` to run local examples page
- Basic TextField and Color categories offer input examples to test out the new feature

Checklist
- [ ] mention text is theme.palette.primary.main
- [ ] cursor shows on non-mention text
- [ ] UI/UX with multiple mentions works as expected

Demo:

https://github.com/user-attachments/assets/442365ad-2b1c-4f04-8bd0-d4033deeef03

