### PR TITLE
ASC1-314: Persist Trigger Character 

### DIFF
--- a/examples/src/ShowTriggerInDisplay.tsx
+++ b/examples/src/ShowTriggerInDisplay.tsx
@@ -22,6 +22,7 @@ export const ShowTriggerInDisplay = () => {
                     fullWidth
                     defaultValue={defaultValue}
                     showTriggerInDisplay={true}
+                    highlightTextColor
                     dataSources={[
                         {
                             data: stormlight,

--- a/examples/src/ShowTriggerInDisplay.tsx
+++ b/examples/src/ShowTriggerInDisplay.tsx
@@ -1,0 +1,34 @@
+import { Stack, Typography } from '@mui/material';
+import React from 'react';
+import { MentionsTextField } from '../../src';
+import { stormlight } from './data';
+
+export const ShowTriggerInDisplay = () => {
+    const defaultValue = 'Hello @[Kaladin Stormblessed](kaladin)';
+
+    return (
+        <Stack spacing={2.5}>
+            <Stack spacing={0.5}>
+                <Typography variant='h5'>Show Trigger In Display</Typography>
+                <Typography>
+                    The showTriggerInDisplay prop preserves the trigger symbol (@, #, etc.) in the displayed mention
+                    text. Below, mentions will display as &quot;@Kaladin Stormblessed&quot;
+                </Typography>
+            </Stack>
+
+            <Stack direction='row' spacing={2}>
+                <MentionsTextField
+                    label='Triggers Preserved in Display'
+                    fullWidth
+                    defaultValue={defaultValue}
+                    showTriggerInDisplay={true}
+                    dataSources={[
+                        {
+                            data: stormlight,
+                        },
+                    ]}
+                />
+            </Stack>
+        </Stack>
+    );
+};

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -25,6 +25,7 @@ import { Images } from './Images';
 import { Limitations } from './Limitations';
 import { Multiline } from './Multiline';
 import { MultipleDataSources } from './MultipleDataSources';
+import { ShowTriggerInDisplay } from './ShowTriggerInDisplay';
 import { Sizes } from './Sizes';
 import { Trigger } from './Trigger';
 
@@ -65,6 +66,7 @@ const App = () => {
                     <Basic />
                     <Trigger />
                     <MultipleDataSources />
+                    <ShowTriggerInDisplay />
                     <AppendSpaceOnAdd />
                     <DisplayTransform />
                     <AsychronousData />

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -116,7 +116,14 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
             : display;
         console.log('🔽 MENTION:', JSON.stringify(finalDisplay), 'at plainTextIndex:', _plainTextIndex);
 
-        components.push(<Mention key={`${id}-${index}`} display={finalDisplay} color={props.color} />);
+        components.push(
+            <Mention
+                key={`${id}-${index}`}
+                display={finalDisplay}
+                color={props.color}
+                highlightTextColor={highlightTextColor}
+            />,
+        );
     };
 
     const handlePlainText = (text: string, index: number, indexInPlaintext: number) => {

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -2,7 +2,7 @@ import { Box, Portal } from '@mui/material';
 import React, { ReactNode } from 'react';
 import Mention from './Mention';
 import { BaseSuggestionData, DefaultTrigger, SuggestionDataSource } from './types';
-import { getPlainText, iterateMentionsMarkup } from './utils/utils';
+import { iterateMentionsMarkup } from './utils/utils';
 
 interface HighlighterProps<T extends BaseSuggestionData> {
     /** Ref applied to the main container of the highlighter. */
@@ -56,52 +56,6 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
     // Convert selection coordinates to the coordinate system used by iterateMentionsMarkup
     // When showTriggerInDisplay is true, selectionStart/End are in "with triggers" coordinates
     // but iterateMentionsMarkup works in "without triggers" coordinates
-    let adjustedSelectionStart = selectionStart;
-    let adjustedSelectionEnd = selectionEnd;
-
-    if (showTriggerInDisplay && selectionStart !== null && selectionEnd !== null) {
-        const displayedText = getPlainText(value, dataSources, multiline, true);
-        const internalText = getPlainText(value, dataSources, multiline, false);
-
-        // Debug logging
-        console.log('🔽 HIGHLIGHTER displayedText:', JSON.stringify(displayedText));
-        console.log('🔽 HIGHLIGHTER internalText:', JSON.stringify(internalText));
-        console.log('🔽 Original selectionStart/End:', selectionStart, selectionEnd);
-
-        // Convert selectionStart
-        let displayPos = 0;
-        let internalPos = 0;
-        while (displayPos < selectionStart && displayPos < displayedText.length && internalPos < internalText.length) {
-            if (displayedText[displayPos] === internalText[internalPos]) {
-                displayPos++;
-                internalPos++;
-            } else {
-                displayPos++; // Skip trigger character in display
-            }
-        }
-        adjustedSelectionStart = internalPos;
-
-        // Convert selectionEnd
-        displayPos = 0;
-        internalPos = 0;
-        while (displayPos < selectionEnd && displayPos < displayedText.length && internalPos < internalText.length) {
-            if (displayedText[displayPos] === internalText[internalPos]) {
-                displayPos++;
-                internalPos++;
-            } else {
-                displayPos++; // Skip trigger character in display
-            }
-        }
-        adjustedSelectionEnd = internalPos;
-
-        console.log('🔽 Adjusted selectionStart/End:', adjustedSelectionStart, adjustedSelectionEnd);
-    }
-
-    // console.log('showTriggerInDisplay', showTriggerInDisplay);
-    // console.log('dataSources', dataSources[0].trigger);
-    // console.log('DefaultTrigger', DefaultTrigger);
-    // console.log('dataSources[0].trigger || DefaultTrigger', dataSources[0].trigger || DefaultTrigger);
-    // console.log('display', display);
 
     const handleMention = (
         _markup: string,
@@ -114,7 +68,6 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
         const finalDisplay = showTriggerInDisplay
             ? (dataSources[mentionIndex].trigger || DefaultTrigger) + display
             : display;
-        console.log('🔽 MENTION:', JSON.stringify(finalDisplay), 'at plainTextIndex:', _plainTextIndex);
 
         components.push(
             <Mention
@@ -131,20 +84,11 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
             text = text.replaceAll('\n', '');
         }
 
-        console.log('🔽 PLAIN TEXT:', JSON.stringify(text), 'at indexInPlaintext:', indexInPlaintext);
-
         const renderCursor =
-            adjustedSelectionStart &&
-            adjustedSelectionStart === adjustedSelectionEnd &&
-            adjustedSelectionStart >= indexInPlaintext &&
-            adjustedSelectionStart <= indexInPlaintext + text.length;
-
-        console.log(
-            '🔽 CURSOR CHECK: renderCursor =',
-            renderCursor,
-            'adjustedSelectionStart =',
-            adjustedSelectionStart,
-        );
+            selectionStart &&
+            selectionStart === selectionEnd &&
+            selectionStart >= indexInPlaintext &&
+            selectionStart <= indexInPlaintext + text.length;
 
         if (!renderCursor) {
             components.push(
@@ -157,7 +101,7 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
                 </Box>,
             );
         } else {
-            const splitIndex = (adjustedSelectionStart || 0) - indexInPlaintext;
+            const splitIndex = (selectionStart || 0) - indexInPlaintext;
             const startText = text.substring(0, splitIndex);
             const endText = text.substring(splitIndex);
 
@@ -189,7 +133,7 @@ function Highlighter<T extends BaseSuggestionData>(props: HighlighterProps<T>): 
         }
     };
 
-    iterateMentionsMarkup(value, dataSources, handleMention, handlePlainText, multiline);
+    iterateMentionsMarkup(value, dataSources, handleMention, handlePlainText, multiline, showTriggerInDisplay);
 
     const rect = getHighlighterRect(props.inputRef);
 

--- a/src/Mention.tsx
+++ b/src/Mention.tsx
@@ -15,7 +15,7 @@ interface MentionProps {
 const Mention: React.FC<MentionProps> = ({ display, color, highlightTextColor }) => {
     if (highlightTextColor) {
         return (
-            <Box component='span' sx={{ position: 'relative' }}>
+            <Box component='span' sx={{ position: 'relative', color: 'transparent' }}>
                 {display}
                 <Box
                     component='span'
@@ -26,6 +26,7 @@ const Mention: React.FC<MentionProps> = ({ display, color, highlightTextColor })
                         right: '0px',
                         bottom: '0px',
                         color: (theme) => theme.palette.primary.main,
+                        zIndex: 1,
                     }}
                 >
                     {display}

--- a/src/MentionsTextField.tsx
+++ b/src/MentionsTextField.tsx
@@ -137,13 +137,13 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
 
     const addMention = (
         suggestion: SuggestionData<T>,
-        { childIndex, querySequenceStart, querySequenceEnd, plainTextValue }: SuggestionsQueryInfo,
+        { childIndex, querySequenceStart, querySequenceEnd, plainTextValue: _plainTextValue }: SuggestionsQueryInfo,
     ) => {
         const dataSource = dataSources[childIndex];
 
         const { markup, displayTransform, appendSpaceOnAdd, onAdd } = dataSource;
 
-        const start = mapPlainTextIndex(finalValue, dataSources, querySequenceStart, 'START');
+        const start = mapPlainTextIndex(finalValue, dataSources, querySequenceStart, 'START', showTriggerInDisplay);
         if (!isNumber(start)) {
             return;
         }
@@ -167,11 +167,11 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
         const newCaretPosition = querySequenceStart + displayValue.length;
         setSelectionStart(newCaretPosition);
         setSelectionEnd(newCaretPosition);
-
         // Propagate change
         const newValue = spliceString(finalValue, start, end, insert);
-        const mentions = getMentions(newValue, dataSources);
-        const newPlainTextValue = spliceString(plainTextValue, querySequenceStart, querySequenceEnd, displayValue);
+        const mentions = getMentions(newValue, dataSources, showTriggerInDisplay);
+
+        const newPlainTextValue = getPlainText(newValue, dataSources, props.multiline, showTriggerInDisplay);
 
         const onChange = props.onChange || setStateValue;
         onChange(newValue, newPlainTextValue, mentions);
@@ -230,7 +230,7 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
         setSelectionStart(selectionStartAfter);
         setSelectionEnd(selectionEndAfter);
 
-        const mentions = getMentions(newValue, dataSources);
+        const mentions = getMentions(newValue, dataSources, showTriggerInDisplay);
 
         // Propagate change
         const onChange = props.onChange || setStateValue;
@@ -244,12 +244,6 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
     };
 
     const inputFieldText = getPlainText(finalValue, dataSources, props.multiline, showTriggerInDisplay);
-
-    // Debug logging
-    console.log('🔼 MARKUP VALUE (finalValue):', JSON.stringify(finalValue));
-    console.log('🔼 INPUT FIELD TEXT (top):', JSON.stringify(inputFieldText));
-    console.log('🔼 showTriggerInDisplay:', showTriggerInDisplay);
-    console.log('🔼 selectionStart/End:', selectionStart, selectionEnd);
 
     const inputProps: TextFieldProps = {
         ...others,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -101,6 +101,8 @@ function findIndexOfCapturingGroup(markup: string, parameterName: 'id' | 'displa
  * @param dataSources An array of all DataSources used in the markup.
  * @param markupProcessor A callback function that processes each mention markup instance.
  * @param plainTextProcessor A callback function that processes each plain text instance.
+ * @param multiline Whether the value is being processed in a multiline context.
+ * @param showTriggerInDisplay Whether to include trigger characters in position calculations.
  */
 export function iterateMentionsMarkup<T extends BaseSuggestionData>(
     value: string,
@@ -116,6 +118,7 @@ export function iterateMentionsMarkup<T extends BaseSuggestionData>(
     ) => void,
     plainTextProcessor?: (value: string, start: number, currentIndex: number) => void,
     multiline?: boolean,
+    showTriggerInDisplay?: boolean,
 ) {
     const regex = combineRegExps(
         dataSources.map((ds) =>
@@ -159,7 +162,15 @@ export function iterateMentionsMarkup<T extends BaseSuggestionData>(
         currentPlainTextIndex += substr.length;
 
         markupProcessor(match[0], match.index, currentPlainTextIndex, id, display, mentionChildIndex, start);
-        currentPlainTextIndex += display.length;
+
+        // Calculate display length including trigger if showTriggerInDisplay is true
+        let mentionDisplayLength = display.length;
+        if (showTriggerInDisplay) {
+            const trigger = dataSources[mentionChildIndex].trigger || DefaultTrigger;
+            mentionDisplayLength += trigger.length;
+        }
+
+        currentPlainTextIndex += mentionDisplayLength;
         start = regex.lastIndex;
     }
 
@@ -182,11 +193,6 @@ export function getPlainText<T extends BaseSuggestionData>(
     showTriggerInDisplay?: boolean,
 ): string {
     let result = '';
-    console.log('📝 getPlainText called with:', {
-        value: JSON.stringify(value),
-        showTriggerInDisplay,
-        multiline,
-    });
 
     iterateMentionsMarkup(
         value,
@@ -195,21 +201,18 @@ export function getPlainText<T extends BaseSuggestionData>(
             if (showTriggerInDisplay) {
                 const trigger = dataSources[mentionIndex].trigger || DefaultTrigger;
                 const mentionText = trigger + display;
-                console.log('📝 Adding mention:', JSON.stringify(mentionText));
                 result += mentionText;
             } else {
-                console.log('📝 Adding mention (no trigger):', JSON.stringify(display));
                 result += display;
             }
         },
         (plainText) => {
-            console.log('📝 Adding plain text:', JSON.stringify(plainText));
             result += plainText;
         },
         multiline,
+        showTriggerInDisplay,
     );
 
-    console.log('📝 getPlainText result:', JSON.stringify(result));
     return result;
 }
 
@@ -311,11 +314,11 @@ export function applyChangeToValue<T extends BaseSuggestionData>(
         spliceEnd = Math.max(selectionEndBefore, selectionStartBefore + lengthDelta);
     }
 
-    let mappedSpliceStart = mapPlainTextIndex(value, dataSources, spliceStart, 'START');
-    let mappedSpliceEnd = mapPlainTextIndex(value, dataSources, spliceEnd, 'END');
+    let mappedSpliceStart = mapPlainTextIndex(value, dataSources, spliceStart, 'START', showTriggerInDisplay);
+    let mappedSpliceEnd = mapPlainTextIndex(value, dataSources, spliceEnd, 'END', showTriggerInDisplay);
 
-    const controlSpliceStart = mapPlainTextIndex(value, dataSources, spliceStart, 'NULL');
-    const controlSpliceEnd = mapPlainTextIndex(value, dataSources, spliceEnd, 'NULL');
+    const controlSpliceStart = mapPlainTextIndex(value, dataSources, spliceStart, 'NULL', showTriggerInDisplay);
+    const controlSpliceEnd = mapPlainTextIndex(value, dataSources, spliceEnd, 'NULL', showTriggerInDisplay);
     const willRemoveMention = controlSpliceStart === null || controlSpliceEnd === null;
 
     let newValue = spliceString(value, mappedSpliceStart || 0, mappedSpliceEnd || 0, insert);
@@ -337,8 +340,8 @@ export function applyChangeToValue<T extends BaseSuggestionData>(
             spliceEnd = oldPlainTextValue.lastIndexOf(plainTextValue.substring(selectionEndAfter));
 
             // re-map the corrected indices
-            mappedSpliceStart = mapPlainTextIndex(value, dataSources, spliceStart, 'START');
-            mappedSpliceEnd = mapPlainTextIndex(value, dataSources, spliceEnd, 'END');
+            mappedSpliceStart = mapPlainTextIndex(value, dataSources, spliceStart, 'START', showTriggerInDisplay);
+            mappedSpliceEnd = mapPlainTextIndex(value, dataSources, spliceEnd, 'END', showTriggerInDisplay);
             newValue = spliceString(value, mappedSpliceStart || 0, mappedSpliceEnd || 0, insert);
         }
     }
@@ -355,6 +358,7 @@ export function applyChangeToValue<T extends BaseSuggestionData>(
  *   START returns the index of the mention markup's first character (default).
  *   END returns the index after the mention markup's last character.
  *   NULL returns null.
+ * @param showTriggerInDisplay Whether the plain text includes trigger characters.
  * @returns The index in the markup string.
  */
 export function mapPlainTextIndex<T extends BaseSuggestionData>(
@@ -362,6 +366,7 @@ export function mapPlainTextIndex<T extends BaseSuggestionData>(
     dataSources: SuggestionDataSource<T>[],
     indexInPlainText: number,
     inMarkupCorrection: 'START' | 'END' | 'NULL' = 'START',
+    showTriggerInDisplay?: boolean,
 ): number | null | undefined {
     if (typeof indexInPlainText !== 'number') {
         return indexInPlainText;
@@ -384,10 +389,19 @@ export function mapPlainTextIndex<T extends BaseSuggestionData>(
         mentionPlainTextIndex: number,
         _id: string,
         display: string,
+        mentionIndex: number,
     ) => {
         if (result !== undefined) return;
 
-        if (mentionPlainTextIndex + display.length > indexInPlainText) {
+        // Calculate actual display length including trigger if showTriggerInDisplay is true
+        let actualDisplayLength = display.length;
+        if (showTriggerInDisplay) {
+            const trigger = dataSources[mentionIndex].trigger || DefaultTrigger;
+            actualDisplayLength += trigger.length;
+        }
+
+        // Now working in unified coordinates that match indexInPlainText
+        if (mentionPlainTextIndex + actualDisplayLength > indexInPlainText) {
             // found the corresponding position inside current match,
             // return the index of the first or after the last char of the matching markup
             // depending on the value of `inMarkupCorrection`
@@ -399,7 +413,7 @@ export function mapPlainTextIndex<T extends BaseSuggestionData>(
         }
     };
 
-    iterateMentionsMarkup(value, dataSources, markupProcessor, plainTextProcessor);
+    iterateMentionsMarkup(value, dataSources, markupProcessor, plainTextProcessor, undefined, showTriggerInDisplay);
 
     // when a mention is at the end of the value and we want to get the cursor position
     // at the end of the string, result is undefined
@@ -433,33 +447,21 @@ export function findStartOfMentionInPlainText<T extends BaseSuggestionData>(
     indexInPlainText: number,
     showTriggerInDisplay?: boolean,
 ): number | undefined {
-    // Find which mention contains this cursor position by rebuilding the displayed text step by step
-    let currentPosition = 0;
     let result: number | undefined = undefined;
 
-    iterateMentionsMarkup(
-        value,
-        dataSources,
-        (_markup, _index, _plainTextIndex, _id, display, mentionIndex) => {
-            // Build the display string the same way getPlainText does
-            let actualDisplay = display;
-            if (showTriggerInDisplay) {
-                const trigger = dataSources[mentionIndex].trigger || DefaultTrigger;
-                actualDisplay = trigger + display;
-            }
+    const markupProcessor = (
+        _markup: string,
+        _index: number,
+        mentionPlainTextIndex: number,
+        _id: string,
+        display: string,
+    ) => {
+        if (mentionPlainTextIndex <= indexInPlainText && mentionPlainTextIndex + display.length > indexInPlainText) {
+            result = mentionPlainTextIndex;
+        }
+    };
 
-            // Check if cursor is within this mention
-            if (currentPosition <= indexInPlainText && indexInPlainText < currentPosition + actualDisplay.length) {
-                result = currentPosition;
-            }
-
-            currentPosition += actualDisplay.length;
-        },
-        (plainText) => {
-            // Add non-mention text
-            currentPosition += plainText.length;
-        },
-    );
+    iterateMentionsMarkup(value, dataSources, markupProcessor, undefined, showTriggerInDisplay);
 
     return result;
 }
@@ -468,22 +470,31 @@ export function findStartOfMentionInPlainText<T extends BaseSuggestionData>(
  * Parses a list of mentions from the given markup string.
  * @param value The markup string value to parse.
  * @param dataSources An array of SuggestionDataSources used in the markup string.
+ * @param showTriggerInDisplay Whether to include trigger characters in position calculations.
  * @returns An array of MentionDatas parsed from the given markup string.
  */
 export function getMentions<T extends BaseSuggestionData>(
     value: string,
     dataSources: SuggestionDataSource<T>[],
+    showTriggerInDisplay?: boolean,
 ): MentionData[] {
     const mentions: MentionData[] = [];
-    iterateMentionsMarkup(value, dataSources, (_match, index, plainTextIndex, id, display, childIndex) => {
-        mentions.push({
-            id,
-            display,
-            dataSourceIndex: childIndex,
-            index,
-            plainTextIndex,
-        });
-    });
+    iterateMentionsMarkup(
+        value,
+        dataSources,
+        (_match, index, plainTextIndex, id, display, childIndex) => {
+            mentions.push({
+                id,
+                display,
+                dataSourceIndex: childIndex,
+                index,
+                plainTextIndex,
+            });
+        },
+        undefined,
+        undefined,
+        showTriggerInDisplay,
+    );
     return mentions;
 }
 
@@ -500,15 +511,28 @@ export function countSuggestions<T extends BaseSuggestionData>(suggestions: Sugg
  * Returns the index of the end of the last mention in the given markup string.
  * @param value The markup string to search for mentions.
  * @param dataSources An array of SuggestionDataSources used in the markup string.
+ * @param showTriggerInDisplay Whether to include trigger characters in position calculations.
  * @returns The index of the end of the last mention, or 0 if there are no mentions.
  */
 export function getEndOfLastMention<T extends BaseSuggestionData>(
     value: string,
     dataSources: SuggestionDataSource<T>[],
+    showTriggerInDisplay?: boolean,
 ) {
-    const mentions = getMentions(value, dataSources);
+    const mentions = getMentions(value, dataSources, showTriggerInDisplay);
     const lastMention = mentions[mentions.length - 1];
-    return lastMention ? lastMention.plainTextIndex + lastMention.display.length : 0;
+    if (!lastMention) {
+        return 0;
+    }
+
+    // Calculate the actual display length including trigger if needed
+    let displayLength = lastMention.display.length;
+    if (showTriggerInDisplay) {
+        const trigger = dataSources[lastMention.dataSourceIndex].trigger || DefaultTrigger;
+        displayLength += trigger.length;
+    }
+
+    return lastMention.plainTextIndex + displayLength;
 }
 
 /**


### PR DESCRIPTION
Ticket: https://augeomarketing.atlassian.net/browse/ASC1-314

New prop: showTriggerInDisplay?: boolean - shows trigger chars (@, #) in mention text

Example: `@[Syl](syl)` displays as `@Syl` instead of Syl

Reworks the index check system to include the possibility of the added trigger char

Demo:

https://github.com/user-attachments/assets/392f267c-56ef-483f-9bb2-10758d58e75e

