### PR TITLE
ASC1-571: Fix Input Placeholder for `highlightTextColor` 

### DIFF
--- a/examples/src/Color.tsx
+++ b/examples/src/Color.tsx
@@ -116,6 +116,7 @@ export const Color = () => {
                         },
                     ]}
                     highlightTextColor={true}
+                    placeholder='Placeholder'
                     focused
                 />
 
@@ -130,6 +131,7 @@ export const Color = () => {
                         },
                     ]}
                     highlightTextColor={true}
+                    placeholder='Placeholder'
                     focused
                 />
 
@@ -144,6 +146,7 @@ export const Color = () => {
                         },
                     ]}
                     highlightTextColor={true}
+                    placeholder='Placeholder'
                     focused
                 />
             </Stack>

--- a/src/MentionsTextField.tsx
+++ b/src/MentionsTextField.tsx
@@ -256,6 +256,14 @@ function MentionsTextField<T extends BaseSuggestionData>(props: MentionsTextFiel
                 overscrollBehavior: 'none',
                 color: highlightTextColor ? 'transparent' : 'inherit',
                 caretColor: highlightTextColor ? 'black' : 'inherit',
+                '&::placeholder': {
+                    color: highlightTextColor ? 'text.secondary' : 'inherit',
+                    opacity: highlightTextColor ? '1 !important' : 'inherit',
+                },
+                '&:focus::placeholder': {
+                    color: highlightTextColor ? 'text.secondary' : 'inherit',
+                    opacity: highlightTextColor ? '1 !important' : 'inherit',
+                },
             },
         },
     };


### PR DESCRIPTION
Fix placeholder visibility when using text color highlighting
Added examples to display placeholder when text color highlighting is true

Manual Testing:
Run locally and find the Color/Text Color Highlighting examples: 
<img width="431" height="355" alt="Screenshot 2025-08-06 at 4 42 17 PM" src="https://github.com/user-attachments/assets/931c6aea-e9e4-435a-9a36-4ea768cf6211" />
